### PR TITLE
Add `info` hook and remove cred printing from `post-deploy`

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,5 @@
+# Improvements
+
+- `genesis info` now includes access key and secret key information, as well as
+  the Minio endpoint. The secret key and access key are no longer printed after
+  deploy.

--- a/hooks/addon
+++ b/hooks/addon
@@ -104,11 +104,12 @@ visit)
     echo "The 'visit' addon script only works on macOS, currently."
     exit 1
   fi
-  echo "Here's the credentials you'll need to sign in: "
+  echo "You will need to enter the following credentials once the page opens: "
   echo
   echo -e "  \033[1m\033[1;36m accesskey: \033[0m $user"
   echo -e "  \033[1m\033[1;36m secretkey: \033[0m $pass"
   echo
+  read -n 1 -s -r -p "Press any key to open the web console..."
   open $minio_url
   exit 0
   ;;

--- a/hooks/info
+++ b/hooks/info
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eu
+
+vault="secret/$GENESIS_VAULT_PREFIX"
+minio_url=$(exodus url)
+
+describe "#B{Minio Information}"
+    echo
+describe "Minio endpoint"
+describe "  #C{https://$(exodus url)}"
+    echo
+describe "Minio credentials"
+describe "  username: #M{$(safe get secret/$GENESIS_VAULT_PREFIX/access_token:accesskey)}"
+describe "  password: #G{$(safe get secret/$GENESIS_VAULT_PREFIX/access_token:secretkey)}"

--- a/hooks/post-deploy
+++ b/hooks/post-deploy
@@ -2,8 +2,6 @@
 set -eu
 
 if [[ $GENESIS_DEPLOY_RC == 0 ]]; then
-  user=$(safe get secret/$GENESIS_VAULT_PREFIX/access_token:accesskey)
-  pass=$(safe get secret/$GENESIS_VAULT_PREFIX/access_token:secretkey)
       echo; echo;
   describe "#M{$GENESIS_ENVIRONMENT} Minio deployed!"
       echo
@@ -22,12 +20,5 @@ if [[ $GENESIS_DEPLOY_RC == 0 ]]; then
       echo "To exec s3 commands with the appropriate envvars set:"
       echo
   describe "  #G{genesis do $GENESIS_ENVIRONMENT -- s3 <command>}"
-
-  echo "Here's the credentials for your newly deployed Minio server. You can"
-  echo "also locate them in the Vault at secret/$GENESIS_VAULT_PREFIX/access_token"
-  echo
-  echo
-  echo -e "  \033[1m\033[1;36m accesskey: \033[0m $user"
-  echo -e "  \033[1m\033[1;36m secretkey: \033[0m $pass"
-  echo
+      echo
 fi


### PR DESCRIPTION
This commit brings the design of the Minio kit more in line with the rest of the Genesis kits by moving credential output into a `genesis info` command.

* Release notes written 💯
* `info` is executable 💯
* Wearing a S&W t-shirt today 💯