### PR TITLE
Upgrade Minio, move to Xenial

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -24,7 +24,7 @@ you.
 * `network` - The `network` that Minio should be
   deployed on. (default: `minio`)
 * `stemcell_os` - The operating system stemcell you
-  want to deploy on. (default: `ubuntu-trusty`)
+  want to deploy on. (default: `ubuntu-xenial`)
 * `stemcell_version` - The specific version of the stemcell
   you want to deploy on. (default: `latest`)
 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,5 +1,16 @@
 # Improvements
 
+- Xenial stemcells are now used by default
+
+- Updated Minio to RELEASE.2018-12-06T01-27-43Z
+  
 - `genesis info` now includes access key and secret key information, as well as
   the Minio endpoint. The secret key and access key are no longer printed after
   deploy.
+
+# Software Components	
+ | Name | Version | Release Notes |	
+| --- | --- | --- |	
+| Minio | 2018-12-06T01-27-43Z | [Release Notes][2018-12-06T01-27-43Z] |
+
+[2018-12-06T01-27-43Z]: https://github.com/minio/minio-boshrelease/releases/tag/RELEASE.2018-12-06T01-27-43Z

--- a/manifests/minio.yml
+++ b/manifests/minio.yml
@@ -3,7 +3,7 @@ instance_groups:
   - name:      minio
     instances: 1
     azs:       (( grab params.availability_zones || meta.default.azs ))
-    stemcell:  default
+    stemcell:  xenial
     networks:
       - name: (( grab params.network || "minio"))
     vm_type:   (( grab params.vm_type || "default" ))
@@ -38,7 +38,7 @@ instance_groups:
     networks:
     - name: (( grab params.network || "minio"))
     vm_type: (( grab params.vm_type || "default" ))
-    stemcell: default
+    stemcell: xenial
     properties:
       debug: false 
 
@@ -51,15 +51,15 @@ update:
   update_watch_time: 5000-600000
 
 stemcells:
-  - alias:   default
-    os:      (( grab params.stemcell_os      || "ubuntu-trusty" ))
+  - alias:   xenial
+    os:      (( grab params.stemcell_os      || "ubuntu-xenial" ))
     version: (( grab params.stemcell_version || "latest" ))
 
 releases:
   - name: "minio"
-    version: "2018-06-08T03-49-38Z"
-    url: "https://bosh.io/d/github.com/minio/minio-boshrelease?v=2018-06-08T03-49-38Z"
-    sha1: "3a5ae84f8b2be9ee640d545c489633e36c0674dd"
+    version: "2018-12-06T01-27-43Z"
+    url: "https://bosh.io/d/github.com/minio/minio-boshrelease?v=2018-12-06T01-27-43Z"
+    sha1: "7e86eb59405fe7c060c8c03353cf9e9fc7fe5691"
 
 meta:
   default:


### PR DESCRIPTION
This PR switches to Xenial stemcells by default, and also includes a Minio upgrade to the latest current BOSH release.