### PR TITLE
Update minio boshrelease to 2020-04-04T05-39-31Z

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,5 @@
+## Updates
+- Bumped bosh-release to 2020-04-04T05-39-31Z
+
+## Bug fixes
+- Default the hook to use path based lookup as minio does not have domain based paths enabled by default

--- a/hooks/addon
+++ b/hooks/addon
@@ -124,6 +124,7 @@ s3)
   export S3_AKI=$user
   export S3_KEY=$pass
   export S3_URL=$minio_url
+  export S3_USE_PATH=yes
   if [[ $(exodus self-signed) ]]; then
     export S3_INSECURE=1
   fi

--- a/manifests/minio.yml
+++ b/manifests/minio.yml
@@ -57,9 +57,9 @@ stemcells:
 
 releases:
   - name: "minio"
-    version: "2019-10-12T01-39-57Z"
-    url: "https://bosh.io/d/github.com/minio/minio-boshrelease?v=2019-10-12T01-39-57Z"
-    sha1: "91fa5e22e9aaaebe9f86e4a08f252c33eac6bbb9"
+    version: "2020-04-04T05-39-31Z"
+    url: "https://bosh.io/d/github.com/minio/minio-boshrelease?v=2020-04-04T05-39-31Z"
+    sha1: "36937ff1661ce88ec50f2bf1a311d27824d13fe2"
 
 meta:
   default:


### PR DESCRIPTION
Also defaults the hook to use path based calls