### PR TITLE
Update Minio Genesis Kit to use Bionic Stemcells

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -24,7 +24,7 @@ you.
 * `network` - The `network` that Minio should be
   deployed on. (default: `minio`)
 * `stemcell_os` - The operating system stemcell you
-  want to deploy on. (default: `ubuntu-xenial`)
+  want to deploy on. (default: `ubuntu-bionic`)
 * `stemcell_version` - The specific version of the stemcell
   you want to deploy on. (default: `latest`)
 

--- a/manifests/minio.yml
+++ b/manifests/minio.yml
@@ -50,7 +50,7 @@ update:
 
 stemcells:
   - alias:   default
-    os:      (( grab params.stemcell_os      || "ubuntu-xenial" ))
+    os:      (( grab params.stemcell_os      || "ubuntu-bionic" ))
     version: (( grab params.stemcell_version || "latest" ))
 
 meta:

--- a/spec/results/base.yml
+++ b/spec/results/base.yml
@@ -54,7 +54,7 @@ releases:
   version: 2021-12-20T22-07-16Z
 stemcells:
 - alias: default
-  os: ubuntu-xenial
+  os: ubuntu-bionic
   version: latest
 update:
   canaries: 1

--- a/spec/results/distributed.yml
+++ b/spec/results/distributed.yml
@@ -55,7 +55,7 @@ releases:
   version: 2021-12-20T22-07-16Z
 stemcells:
 - alias: default
-  os: ubuntu-xenial
+  os: ubuntu-bionic
   version: latest
 update:
   canaries: 1


### PR DESCRIPTION
Verified `v0.5.1` to `v0.5.2-rc2` upgrade path locally:

```$ genesis info vcenter

Verifying availability of vault 'vcenter' (https://x.x.x.x)...ok


================================================================================

MINIO Deployment for Environment 'vcenter'

  Last deployed about 2 minutes ago (08:13PM on Jan 06, 2022 UTC)
             by jdee
        to BOSH vcenter
   based on kit minio/0.5.2-rc1
          using Genesis v2.8.4
  with manifest .genesis/manifests/vcenter.yml (redacted)

       Features self-signed-cert

--------------------------------------------------------------------------------

Minio Information

Minio endpoint
  https://x.x.x.x:443

Minio credentials
  username: XXX
  password: XXX

================================================================================
```